### PR TITLE
fix: check for elements is always true

### DIFF
--- a/src/Resources/public/js/recaptcha.js
+++ b/src/Resources/public/js/recaptcha.js
@@ -8,7 +8,7 @@ googleRecaptchaScript.addEventListener('load', function() {
     grecaptcha.ready(function () {
         var elements = document.querySelectorAll(_config.googleRecaptcha.querySelector);
 
-        if (elements) {
+        if (elements.length > 0) {
             for (var element of elements) {
                 var action = "action" in element.dataset ? element.dataset["action"] : false;
                 action = action ? action : _config.googleRecaptcha.defaultAction;


### PR DESCRIPTION
`var elements = document.querySelectorAll(_config.googleRecaptcha.querySelector);` returns a `NodeList`, thus, we need to check for the length of the list.