### PR TITLE
fix: check if the form needs to be submitted

### DIFF
--- a/src/Resources/public/js/recaptcha.js
+++ b/src/Resources/public/js/recaptcha.js
@@ -34,7 +34,13 @@ googleRecaptchaScript.addEventListener('load', function() {
 
                                 element.value = token;
 
-                                form.dispatchEvent(new Event('submit'));
+                                var doSubmit = form.dispatchEvent(new Event('submit', {
+                                    cancelable: true
+                                }));
+                                
+                                if(doSubmit) {
+                                    form.submit();
+                                }
                             });
                         });
                     }


### PR DESCRIPTION
The submit `Event` was only triggered, making it possible to execute listeners to this event. However, the form submission itself was never executed (unless manually triggered in an event listener).

This PR checks if the form is supposed to be submitted and does submit it if `e.preventDefault()` was _not_ called.