### PR TITLE
fix: add recaptcha form validation check

### DIFF
--- a/src/Resources/public/js/recaptcha.js
+++ b/src/Resources/public/js/recaptcha.js
@@ -33,17 +33,18 @@ googleRecaptchaScript.addEventListener('load', function() {
 
                             form.querySelector(_config.googleRecaptcha.querySelector).value = token;
 
-                            var doSubmit = form.dispatchEvent(new Event('submit', {
-                                cancelable: true
-                            }));
-
-                            if(doSubmit) {
-                                form.submit();
+                            if (form.checkValidity()) {
+                                var doSubmit = form.dispatchEvent(new Event('submit', {
+                                    cancelable: true
+                                }));
+    
+                                if (doSubmit) {
+                                    form.submit();
+                                }
                             }
                         });
                     });
                 }
-
             }
         } else if (_config.googleRecaptcha.debug) {
             console.debug("Could not find Google Recaptcha elements for query selector '" + _config.googleRecaptcha.querySelector + "'");

--- a/src/Resources/public/js/recaptcha.js
+++ b/src/Resources/public/js/recaptcha.js
@@ -33,7 +33,7 @@ googleRecaptchaScript.addEventListener('load', function() {
 
                             form.querySelector(_config.googleRecaptcha.querySelector).value = token;
 
-                            if (form.checkValidity()) {
+                            if (form.noValidate || form.reportValidity()) {
                                 var doSubmit = form.dispatchEvent(new Event('submit', {
                                     cancelable: true
                                 }));


### PR DESCRIPTION
Uses [checkValidity()](https://caniuse.com/form-validation) function to implement simple [form validation check](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/checkValidity) to prevent form submission if form is invalid.

closes #6 